### PR TITLE
ナビゲーションバーに図書館Wikiへのリンクを追加

### DIFF
--- a/app/assets/javascripts/components/features/getting_started/index.jsx
+++ b/app/assets/javascripts/components/features/getting_started/index.jsx
@@ -19,7 +19,8 @@ const messages = defineMessages({
   favourites: { id: 'navigation_bar.favourites', defaultMessage: 'Favourites' },
   blocks: { id: 'navigation_bar.blocks', defaultMessage: 'Blocked users' },
   mutes: { id: 'navigation_bar.mutes', defaultMessage: 'Muted users' },
-  info: { id: 'navigation_bar.info', defaultMessage: 'Extended information' }
+  info: { id: 'navigation_bar.info', defaultMessage: 'Extended information' },
+  library: { id: 'navigation_bar.library', defaultMessage: 'Library (Wiki)' }
 });
 
 const mapStateToProps = state => ({
@@ -44,7 +45,8 @@ const GettingStarted = ({ intl, me }) => {
         <ColumnLink icon='volume-off' text={intl.formatMessage(messages.mutes)} to='/mutes' />
         <ColumnLink icon='ban' text={intl.formatMessage(messages.blocks)} to='/blocks' />
         <ColumnSubheading text={intl.formatMessage(messages.settings_subheading)}/>
-        <ColumnLink icon='book' text={intl.formatMessage(messages.info)} href='/about/more' />
+        <ColumnLink icon='server' text={intl.formatMessage(messages.info)} href='/about/more' />
+        <ColumnLink icon='book' text={intl.formatMessage(messages.library)} href='http://library.kemono-friends.info' />
         <ColumnLink icon='cog' text={intl.formatMessage(messages.preferences)} href='/settings/preferences' />
         <ColumnLink icon='sign-out' text={intl.formatMessage(messages.sign_out)} href='/auth/sign_out' method='delete' />
       </div>

--- a/app/assets/javascripts/components/locales/ja.jsx
+++ b/app/assets/javascripts/components/locales/ja.jsx
@@ -83,6 +83,7 @@ const ja = {
   "navigation_bar.mutes": "ミュートしたユーザー",
   "navigation_bar.preferences": "ユーザー設定",
   "navigation_bar.public_timeline": "ジャパリパーク",
+  "navigation_bar.library": "としょかん (Wiki)",
   "notification.favourite": "{name} さんがあなたのがおーにすごーいしました",
   "notification.follow": "{name} さんにフォローされました",
   "notification.mention": "{name} さんがあなたにおしゃべりしました",


### PR DESCRIPTION
- サーバー情報とログアウトの間に としょかん(Wiki) の項目を追加
- 日本語以外のロケールでは "Library (Wiki)"。
- アイコンのbookを使うためにサーバー情報のアイコンをbookからserverへ変更

<img width="322" alt="default" src="https://cloud.githubusercontent.com/assets/1283235/25438852/9f041270-2ad5-11e7-99e4-710a10d116ac.PNG">

不明な点があれば @na128@mstdn.kemono-friends.info までお問い合わせください。